### PR TITLE
修复 /ai/consult 请求体并兼容旧路径 /api/ai/consult

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -59,6 +59,10 @@ def get_db():
     finally:
         db.close()
 
+
+def run_agent(text: str):
+    return text
+
 # ---------- Pydantic IO ----------
 class CaseCreate(BaseModel):
     patient_name: str
@@ -100,6 +104,9 @@ class AnalyzeOut(BaseModel):
     analysis: str
     treatment: str
     prognosis: str
+
+class AIConsultIn(BaseModel):
+    text: str
 
 # ---------- 统一前缀 /api ----------
 api = APIRouter(prefix="/api", tags=["cases"])
@@ -303,6 +310,15 @@ def reanalyze_case(
 
     db.add(obj); db.commit(); db.refresh(obj)
     return obj
+
+
+@app.post("/ai/consult", tags=["ai"])
+@app.post("/api/ai/consult", tags=["ai"])
+async def ai_consult(data: AIConsultIn):
+    result = run_agent(data.text)
+    if isinstance(result, dict):
+        return result
+    return {"result": result}
 
 # 将 /api 路由挂载到应用
 app.include_router(api)


### PR DESCRIPTION
### Motivation
- Swagger 上的 `/ai/consult` 没有 Request body，点击 Execute 会发送空 body 导致 JSONDecodeError，需要让 FastAPI/Swagger 显示并强制要求请求体。 
- 变更应尽量最小化并同时兼容历史路径 `POST /api/ai/consult`，避免大规模重构。

### Description
- 在 `backend/main.py` 新增 Pydantic 模型 `AIConsultIn`，定义为 `text: str`，以便生成 Swagger 的 Request body。 
- 新增 `ai_consult` 处理函数并为其添加两条路由：`POST /ai/consult` 与兼容的 `POST /api/ai/consult`，处理签名为 `data: AIConsultIn`。 
- 在处理函数内部调用 `run_agent(data.text)`；保留返回结构：若 `run_agent` 返回 `dict` 则直接返回，否则包装为 `{"result": ...}`。 
- 添加了一个最小化的 `run_agent(text: str)` stub 以避免未定义错误，所有改动局限于 `backend/main.py`，未做大规模重构。

### Testing
- 执行了 `python3 -m py_compile backend/main.py`，结果成功（无语法错误）。
- 未运行其它自动化测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef75d6b9248321b474c2ad225902a2)