### PR TITLE
feat: semi-auto Agent v1 — backend consult + frontend tree linking

### DIFF
--- a/backend/agent_orchestrator.py
+++ b/backend/agent_orchestrator.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def _contains_any(text: str, keywords: List[str]) -> bool:
+    return any(k in text for k in keywords)
+
+
+def run_agent(text: str) -> Dict[str, Any]:
+    """
+    半自动 Agent v1（实用级）最小编排器：
+    - 只做规则路由与风险分层
+    - 所有结论都需要医生确认
+    """
+    raw = (text or "").strip()
+    norm = raw.lower()
+
+    vomiting_hit = _contains_any(norm, ["vomit", "vomiting", "呕吐", "吐"])
+    low_energy_hit = _contains_any(norm, ["精神差", "嗜睡", "没精神", "萎靡", "letharg", "depressed"])
+    anorexia_hit = _contains_any(norm, ["不吃", "厌食", "食欲差", "食欲下降", "anorexia", "not eating"])
+    long_duration_hit = _contains_any(norm, ["两天", "2天", "48小时", "2 days", "two days"])
+    red_flag_hit = _contains_any(norm, ["血", "黑便", "腹胀", "干呕", "毒物", "无尿", "coffee ground"])
+
+    route_to = "vomiting" if vomiting_hit else "general"
+
+    if red_flag_hit:
+        risk_level = "high"
+    elif vomiting_hit and (low_energy_hit or anorexia_hit or long_duration_hit):
+        risk_level = "high"
+    elif vomiting_hit:
+        risk_level = "medium"
+    else:
+        risk_level = "low"
+
+    tree_best_path = ["消化系统", "胃肠道", "急性呕吐"] if route_to == "vomiting" else ["综合评估"]
+
+    candidate_diseases: List[str] = []
+    if route_to == "vomiting":
+        candidate_diseases = ["急性胃肠炎", "胃肠道异物", "胰腺炎", "毒物相关胃肠道反应"]
+    else:
+        candidate_diseases = ["待完善分诊信息后生成"]
+
+    checks = [
+        "体温/心率/呼吸频率/脱水程度",
+        "腹部触诊与疼痛评估",
+        "CBC+生化+电解质",
+        "必要时腹部X线或超声",
+    ]
+    actions = [
+        "先行止吐与补液支持",
+        "若出现红旗信号，立即急诊处理",
+        "检查结果回填后由医生确认处置路径",
+    ]
+
+    return {
+        "agent_mode": "semi_auto_v1",
+        "chief_complaint": raw,
+        "route_to": route_to,
+        "risk_level": risk_level,
+        "features": {
+            "vomiting": vomiting_hit,
+            "low_energy": low_energy_hit,
+            "anorexia": anorexia_hit,
+            "duration_ge_48h": long_duration_hit,
+            "red_flags": red_flag_hit,
+        },
+        "tree_best_path": tree_best_path,
+        "next_questions": [
+            "呕吐频次与持续时长？",
+            "是否有血性/咖啡色呕吐物？",
+            "是否腹痛、腹胀、干呕无物？",
+            "近期是否误食异物/毒物？",
+            "尿量与精神状态是否进一步下降？",
+        ],
+        "candidate_diseases": candidate_diseases,
+        "checks": checks,
+        "actions": actions,
+        "doctor_confirmation_required": True,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from db import SessionLocal, Base, engine
 from models import Case
 from auth_jwt import router as auth_router, get_current_user
+from agent_orchestrator import run_agent
 
 # ---------- 初始化 ----------
 Base.metadata.create_all(bind=engine)
@@ -101,6 +102,10 @@ class AnalyzeOut(BaseModel):
     treatment: str
     prognosis: str
 
+
+class AgentConsultIn(BaseModel):
+    text: str
+
 # ---------- 统一前缀 /api ----------
 api = APIRouter(prefix="/api", tags=["cases"])
 # --- triage (hospital) ---
@@ -159,6 +164,11 @@ def analyze(data: AnalyzeIn):
     analysis = "可能的鉴别诊断：\n- " + "\n- ".join(dict.fromkeys(ddx)) if ddx else "需进一步完善检查以明确病因。"
     treatment = "建议的处理/治疗：\n- " + "\n- ".join(dict.fromkeys(plan)) if plan else "建议完善血常规/生化/电解质/影像后再定方案。"
     return AnalyzeOut(analysis=analysis, treatment=treatment, prognosis=prognosis)
+
+
+@app.post("/ai/consult", tags=["agent"])
+def ai_consult(data: AgentConsultIn):
+    return run_agent(data.text)
 
 # 工具：检测是否有软删字段
 def supports_soft_delete() -> bool:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import api from "./api";
 import CaseDetail from "./pages/CaseDetail";
 import CaseEditorPage from "./pages/CaseEditorLite";
+import AISection from "./components/AISection";
 
 /** ===== 首页 Home 组件 ===== */
 function Home() {
@@ -389,6 +390,11 @@ function Home() {
             {prognosis && <Block title="预后">{prognosis}</Block>}
           </div>
         )}
+      </section>
+
+      <section style={card}>
+        <h2 style={h2}>2.1) 半自动 Agent v1（实用级）</h2>
+        <AISection />
       </section>
 
       {/* ====== 列表（搜索+分页 + 批量操作） ====== */}

--- a/frontend/src/components/AIPetConsultBox.jsx
+++ b/frontend/src/components/AIPetConsultBox.jsx
@@ -1,0 +1,67 @@
+import React, { useMemo, useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000";
+
+function normalizePath(path) {
+  if (!Array.isArray(path)) return [];
+  return path.map((x) => String(x || "").trim()).filter(Boolean);
+}
+
+export default function AIPetConsultBox({ onResult, onTreePathLocate }) {
+  const [text, setText] = useState("狗狗两天不吃东西，呕吐，精神差");
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const treePathText = useMemo(
+    () => (result?.tree_best_path || []).join(" → "),
+    [result]
+  );
+
+  const submit = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(`${API_BASE}/ai/consult`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const normalizedPath = normalizePath(data?.tree_best_path);
+      setResult(data);
+      onResult?.(data);
+      onTreePathLocate?.(normalizedPath);
+    } catch (e) {
+      setError(`调用失败：${String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 12 }}>
+      <h3 style={{ marginTop: 0 }}>AI 半自动问诊</h3>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={3}
+        style={{ width: "100%" }}
+      />
+      <div style={{ marginTop: 8 }}>
+        <button onClick={submit} disabled={loading}>
+          {loading ? "分析中…" : "调用 /ai/consult"}
+        </button>
+      </div>
+      {error && <p style={{ color: "crimson" }}>{error}</p>}
+      {result && (
+        <div style={{ marginTop: 10, fontSize: 14 }}>
+          <div><b>risk_level:</b> {result.risk_level}</div>
+          <div><b>route_to:</b> {result.route_to}</div>
+          <div><b>tree_best_path:</b> {treePathText}</div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/AISection.jsx
+++ b/frontend/src/components/AISection.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from "react";
+import AIPetConsultBox from "./AIPetConsultBox";
+import VomitingTree from "./VomitingTree";
+
+export default function AISection() {
+  const [result, setResult] = useState(null);
+  const [treePath, setTreePath] = useState([]);
+
+  return (
+    <section style={{ marginTop: 16 }}>
+      <AIPetConsultBox
+        onResult={(data) => setResult(data)}
+        onTreePathLocate={(normalizedPath) => setTreePath(normalizedPath)}
+      />
+      <div style={{ marginTop: 12, border: "1px solid #e5e7eb", borderRadius: 12 }}>
+        <VomitingTree targetPath={treePath} />
+      </div>
+      {result?.doctor_confirmation_required && (
+        <p style={{ marginTop: 8, color: "#92400e" }}>
+          当前为半自动建议，需医生最终确认。
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/VomitingTree.tsx
+++ b/frontend/src/components/VomitingTree.tsx
@@ -1,5 +1,5 @@
 // frontend/src/components/VomitingTree.tsx
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type Prompt = { id: string; text: string; text_zh: string; text_en: string; };
 type Node = {
@@ -11,9 +11,37 @@ type Node = {
   children?: Node[];
 };
 
-export default function VomitingTree() {
+type Props = {
+  targetPath?: string[];
+};
+
+function normalizeLabel(text: string) {
+  return (text || "").replace(/[（(].*?[）)]/g, "").replace(/\s+/g, "").trim();
+}
+
+function buildLabelIndex(root: Node, map: Map<string, string>) {
+  map.set(normalizeLabel(root.label_zh || root.label), root.id);
+  map.set(normalizeLabel(root.label_en || root.label), root.id);
+  (root.children || []).forEach((c) => buildLabelIndex(c, map));
+}
+
+function buildParentMap(root: Node, parent: string | null, map: Map<string, string | null>) {
+  map.set(root.id, parent);
+  (root.children || []).forEach((c) => buildParentMap(c, root.id, map));
+}
+
+const PATH_ALIAS_TO_ID: Record<string, string> = {
+  "消化系统": "vomiting",
+  "胃肠道": "triage",
+  "急性呕吐": "triage.acute",
+};
+
+export default function VomitingTree({ targetPath = [] }: Props) {
   const [data, setData] = useState<Node | null>(null);
   const [locale, setLocale] = useState<"zh" | "en">("zh");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [activeId, setActiveId] = useState<string>("");
+  const nodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   useEffect(() => {
     fetch(`/api/v1/vomiting/tree?locale=${locale}&embed=prompts`)
@@ -21,9 +49,50 @@ export default function VomitingTree() {
       .then(d => setData(d.root));
   }, [locale]);
 
+  const idPath = useMemo(() => {
+    if (!data || !targetPath.length) return [];
+    const labelIndex = new Map<string, string>();
+    buildLabelIndex(data, labelIndex);
+    return targetPath
+      .map((label) => labelIndex.get(normalizeLabel(label)) || PATH_ALIAS_TO_ID[normalizeLabel(label)] || "")
+      .filter(Boolean);
+  }, [data, targetPath]);
+
+  useEffect(() => {
+    if (!data || !idPath.length) return;
+    const parentMap = new Map<string, string | null>();
+    buildParentMap(data, null, parentMap);
+
+    const toExpand = new Set<string>();
+    idPath.forEach((id) => {
+      let cur: string | null | undefined = id;
+      while (cur) {
+        toExpand.add(cur);
+        cur = parentMap.get(cur) || null;
+      }
+    });
+    setExpandedIds(toExpand);
+    const lastId = idPath[idPath.length - 1];
+    setActiveId(lastId);
+    setTimeout(() => {
+      nodeRefs.current[lastId]?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 50);
+  }, [data, idPath]);
+
   const renderNode = (n: Node) => (
     <li key={n.id} style={{marginBottom: 8}}>
-      <div style={{fontWeight: 600}}>{locale === "zh" ? n.label_zh || n.label : n.label_en || n.label}</div>
+      <div
+        ref={(el) => { nodeRefs.current[n.id] = el; }}
+        style={{
+          fontWeight: 600,
+          borderRadius: 6,
+          padding: "4px 6px",
+          background: activeId === n.id ? "#fef3c7" : "transparent",
+          border: activeId === n.id ? "1px solid #f59e0b" : "1px solid transparent",
+        }}
+      >
+        {locale === "zh" ? n.label_zh || n.label : n.label_en || n.label}
+      </div>
       {n.prompts && n.prompts.length > 0 && (
         <ul>
           {n.prompts.map(p => (
@@ -33,7 +102,7 @@ export default function VomitingTree() {
           ))}
         </ul>
       )}
-      {n.children && n.children.length > 0 && (
+      {n.children && n.children.length > 0 && expandedIds.has(n.id) && (
         <ul style={{marginLeft: 12}}>
           {n.children.map(renderNode)}
         </ul>


### PR DESCRIPTION
### Motivation
- Provide a minimal, practical “半自动 Agent v1” that can perform rule-based routing and risk stratification and always require doctor confirmation. 
- Expose a simple backend endpoint for consults and wire it to the existing frontend so the UI can call the agent and visualize the suggested tree path. 
- Ensure the VomitingTree can accept AI-returned Chinese path labels and reliably expand/highlight/scroll to the matching node with minimal changes.

### Description
- Add `backend/agent_orchestrator.py` implementing `run_agent(text: str) -> dict` that returns the mandated fields (`agent_mode`, `chief_complaint`, `route_to`, `risk_level`, `features`, `tree_best_path`, `next_questions`, `candidate_diseases`, `checks`, `actions`, `doctor_confirmation_required`).
- Modify `backend/main.py` to import `run_agent`, add `AgentConsultIn` model and a new `POST /ai/consult` route which returns the `run_agent` result, while keeping `/healthz` unchanged and mounting the knowledge-base static path.
- Add frontend component `frontend/src/components/AIPetConsultBox.jsx` which calls `POST /ai/consult`, then runs `setResult(data)`, `onResult(data)`, and `onTreePathLocate(normalizedPath)` on success and displays `risk_level/route_to/tree_best_path`.
- Add `frontend/src/components/AISection.jsx` to connect `AIPetConsultBox` with the tree viewer and surface the doctor-confirmation note.
- Update `frontend/src/components/VomitingTree.tsx` to accept `targetPath`, implement label normalization and a Chinese-label→node.id mapping (with small alias table), and perform automatic expanding, highlighting, and smooth scrolling to the located node.
- Insert `AISection` into the main UI by updating `frontend/src/App.jsx`.

### Testing
- Ran Python byte-compile for changed backend modules with `python3 -m py_compile backend/main.py backend/agent_orchestrator.py backend/app/main.py backend/app/routers/vomiting.py`, which succeeded.
- Built the frontend with `npm run build` in `frontend`, which succeeded (Vite build completed).
- Attempted to start the backend via `uvicorn` and call the new endpoint in-container, but `uvicorn` was not available in the environment so the live server start / curl test could not be completed here (please install dependencies and run locally to exercise the HTTP behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef694806a08321917f8961cfc2ae06)